### PR TITLE
时间类型数据插入异常问题更改

### DIFF
--- a/datafaker/dbs/rdbdb.py
+++ b/datafaker/dbs/rdbdb.py
@@ -29,7 +29,8 @@ class RdbDB(BaseDB):
 
         sql = u"insert into {table} ({column_names}) values {values}".format(
             table=self.args.table, column_names=column_names, values=u','.join([item for item in batch_value]))
-        self.session.execute(sql)
+		sql = sql.replace('\'\'', '\'')
+		self.session.execute(sql)
 
         self.session.commit()
 


### PR DESCRIPTION
meta文件中配置如时间类型时如
capStampTime||varchar(64)||捕获时间[:date(-5d,-0d, '%Y-%m-%d %H:%M:%S')]
capStampDate||datetime||捕获日期[:date(-5d,-0d, '%Y-%m-%d')]
会导致生成插入sql异常如
insert into rebody_t (reBodyId,cameraId,dayReid,permanentReid,captureId,traceId,capTimestamp,bodyRect,captureImg,quality,panoramicImg,captureImgUrl,panoramicImgUrl,appId,createTime,capStampTime,capStampDate) values ('47c486a4959561f008cb3d1bdf6efc98',1,30294,'2807','rCZMiKdVwFXZxZnFOsKAGrpemTiezEBMZcwboVPNEGHtLFpYhYoFjRExzpmDJlS',67,1580700634,'OpWmUeLptGaeJMGgfkQbLlJdxKIcVRHXLtsUlFDImAgdOaZAvztxKmBnZbWCaJTcNvEHLfGEibEoCJnkJrIRBNDWFPambrSQlJnYIzJvtsNSlGlfyENZQBbAnxMuDdnbazYZRqcYCJVRpGxNDvjaZYIHXMyDRzeTRhDchyUYEaKOYeEGLDzCrpwARYjocp','MKeBOfVLirRMzoUPdKwEgbqPQvbOSWKZHYUkEamOenXNzNYhAYFwXUWblNpnStlRYrZQnuhchYymDNvYWsvEpTvHjmEwyjgYebsMubCYqqVPQFZDmeCraFunFyojvkGUfTSqEHUtltBwwAShTKoqmgDXoCGXCeONHzTYNtvwIOUNjxCyHyIFvrhcUnRmJLzlKwszTsLwjxHtzjbWSVprhRsjBswPgsMzmBZzzRMJCuHqHrXsdaHqC',7,'fsqKXpwUDWyCqhngtuzorNOWPUTRPnfNKPECNdJtegrxMitVSczjqeffOLdkfGUPMGKaLilgkHaxzgAElLEPDexowqEVJsDWkcBDdGVNhTsdXVnQKSQdLEgNBoGJlbAxBmoIePRFAemCsadKbHcTEGffyujjRLjMBNiUxjokozVXDIaHGufsAsqBIOpNoQpUyYflMLtnQuoMJDiUlUwMAyIpljbApuvOhrdYAbdBfpc','XhZmJIVtHRaYzODDjroHScjVAVBeQAfUFXqeGrNSBIvxiLQeYrhjnelwcfbAJkgYeurNvzDTu','QgCTpvmSVnbODsrQUljbXHhSiLIKfobvHjmilwjlfnCeoUkjikiDOSeUtBjAlcWlREqQGnIGndMoykifxvcsWcfaJtKsbAnHWwWOG',69,'a',''2020-01-31 00:00:00'',''2020-01-30'')
其中的''不是“而是‘’
因此在rdbdb.py中增加对这种情况的处理，望采纳